### PR TITLE
Introduce spring-boot and lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 		classpath "com.diffplug.gradle.spotless:spotless:1.3.3"
 		classpath "de.thetaphi:forbiddenapis:2.2"
 		classpath "de.aaschmid:gradle-cpd-plugin:1.0"
-		classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8"
 	}
 }
 
@@ -29,7 +28,6 @@ apply plugin: "cpd"
 apply plugin: "jacoco"
 apply plugin: "de.thetaphi.forbiddenapis"
 apply plugin: "com.diffplug.gradle.spotless"
-apply plugin: "net.ltgt.errorprone"
 
 // code quality configuration
 apply from: 'gradle/quality/checkstyle.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 	// spring
 	compile "org.springframework.boot:spring-boot-starter:$springBootVersion"
 
+	// other
+	compileOnly "org.projectlombok:lombok:$lombokVersion"
+
 	// testing
 	testCompile "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,13 @@ buildscript {
 		classpath "com.diffplug.gradle.spotless:spotless:1.3.3"
 		classpath "de.thetaphi:forbiddenapis:2.2"
 		classpath "de.aaschmid:gradle-cpd-plugin:1.0"
+		classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
 	}
 }
 
 // basic plugins
 apply plugin: "java"
+apply plugin: "spring-boot"
 
 // custom configuration
 apply from: 'gradle/version.gradle'
@@ -52,13 +54,20 @@ tasks.withType(AbstractCompile) each {
 compileJava {
 	options.compilerArgs << "-Werror"
 	options.compilerArgs << "-Xlint:all" << "-Xlint:-processing" << "-Xlint:-deprecation"
-	options.compilerArgs << "-Xep:MissingOverride:OFF"
 }
 
 // libraries
 repositories {
 	jcenter()
 	mavenCentral()
+}
+
+dependencies {
+	// spring
+	compile "org.springframework.boot:spring-boot-starter:$springBootVersion"
+
+	// testing
+	testCompile "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
 }
 
 // wrapper

--- a/config/spotless/spotless.license.java
+++ b/config/spotless/spotless.license.java
@@ -1,10 +1,15 @@
 /*
- * Copyright 2015-2016 Classmethod, Inc.
- * All Rights Reserved.
+ * Copyright 2017 the original author or authors.
  *
- * NOTICE:  All source code, documentation and other information
- * contained herein is, and remains the property of Classmethod, Inc.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Classmethod, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+# dependency versions
+springBootVersion = 1.4.0.RELEASE
+
+lombokVersion = 1.16.2

--- a/src/main/java/jp/classmethod/sparrow/ExampleCommandlineRunner.java
+++ b/src/main/java/jp/classmethod/sparrow/ExampleCommandlineRunner.java
@@ -1,0 +1,26 @@
+package jp.classmethod.sparrow;
+
+import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * サンプルの {@link CommandLineRunner} 実装。
+ *
+ * <p>ログに {@code Hello, world!} 及び、コマンドライン引数（あれば）を出力する。</p>
+ *
+ * @author daisuke
+ * @since #version#
+ */
+@Slf4j
+@Component
+public class ExampleCommandlineRunner implements CommandLineRunner {
+
+	@Override
+	public void run(String... args) throws Exception {
+		log.info("Hello, world!");
+		Arrays.stream(args).forEach(log::info);
+	}
+}

--- a/src/main/java/jp/classmethod/sparrow/ExampleCommandlineRunner.java
+++ b/src/main/java/jp/classmethod/sparrow/ExampleCommandlineRunner.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jp.classmethod.sparrow;
 
 import java.util.Arrays;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +33,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class ExampleCommandlineRunner implements CommandLineRunner {
-
+	
 	@Override
 	public void run(String... args) {
 		log.info("Hello, world!");

--- a/src/main/java/jp/classmethod/sparrow/ExampleCommandlineRunner.java
+++ b/src/main/java/jp/classmethod/sparrow/ExampleCommandlineRunner.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 public class ExampleCommandlineRunner implements CommandLineRunner {
 
 	@Override
-	public void run(String... args) throws Exception {
+	public void run(String... args) {
 		log.info("Hello, world!");
 		Arrays.stream(args).forEach(log::info);
 	}

--- a/src/main/java/jp/classmethod/sparrow/SparrowApplication.java
+++ b/src/main/java/jp/classmethod/sparrow/SparrowApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jp.classmethod.sparrow;
 
 import org.springframework.boot.SpringApplication;
@@ -13,7 +28,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  */
 @SpringBootApplication
 public class SparrowApplication {
-
+	
 	public static void main(String[] args) {
 		SpringApplication.run(SparrowApplication.class, args);
 	}

--- a/src/main/java/jp/classmethod/sparrow/SparrowApplication.java
+++ b/src/main/java/jp/classmethod/sparrow/SparrowApplication.java
@@ -1,0 +1,20 @@
+package jp.classmethod.sparrow;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Sparrowアプリケーションのエントリーポイント。
+ *
+ * <p>ベーシックなSpring bootアプリケーションクラス。</p>
+ *
+ * @author daisuke
+ * @since #version#
+ */
+@SpringBootApplication
+public class SparrowApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SparrowApplication.class, args);
+	}
+}


### PR DESCRIPTION
- lombok導入
    - errorproneとの[相性問題](https://github.com/google/error-prone/issues/347)により、errorproneを無効化。
- spring-boot導入
- 最初のサンプルとして、ログ出力のアプリを実装。

下記コマンドにより、アプリケーションを起動できる。

```
$ ./gradlew bootRun
```

ログ中に `Hello, world!` が出ていれば正常。