### PR TITLE
Calclatorのテスト対象メソッドを変更

### DIFF
--- a/src/main/java/jp/classmethod/sparrow/model/LineBotService.java
+++ b/src/main/java/jp/classmethod/sparrow/model/LineBotService.java
@@ -63,7 +63,8 @@ public class LineBotService {
 	/**
 	 * Lineの署名検証を行う
 	 * https://devdocs.line.me/ja/#webhooks
-	 * @param expected HTTPヘッダ X-Line-Signature の値
+	 *
+	 * @param expected    HTTPヘッダ X-Line-Signature の値
 	 * @param requestBody Body部の文字列
 	 * @return ヘッダと計算結果が一致していればtrue. 不一致や計算失敗の場合はfalse
 	 */
@@ -79,9 +80,10 @@ public class LineBotService {
 	
 	/**
 	 * 署名検証用のシグネチャを計算する
+	 *
 	 * @param requestBody リクエストの本体
 	 * @return シグネチャの計算結果
-	 * @throws GeneralSecurityException　設定したChannelSecretが異常だった時
+	 * @throws GeneralSecurityException 　設定したChannelSecretが異常だった時
 	 */
 	String calculateRequestSignature(String requestBody) throws GeneralSecurityException {
 		String channelSecret = configurationProperties.getChannelSecret();
@@ -96,6 +98,7 @@ public class LineBotService {
 	
 	/**
 	 * JSON文字列をLineWebhookRequest型に変換する
+	 *
 	 * @param request リクエスト本体のJSON文字列
 	 * @return LineWebhookRequest型のインスタンス
 	 * @throws IOException
@@ -105,7 +108,6 @@ public class LineBotService {
 	}
 	
 	/**
-	 *
 	 * @param event Lineイベント情報
 	 */
 	public void echoBot(LineEvent event, String responseText) {
@@ -155,6 +157,7 @@ public class LineBotService {
 	
 	/**
 	 * リクエストの内容を確認する
+	 *
 	 * @param event Lineイベント情報
 	 * @return イベントがmessageタイプ＆textタイプである場合はtrue,そうでない場合はfalseを返す
 	 */

--- a/src/test/java/jp/classmethod/sparrow/model/CalcServiceTest.java
+++ b/src/test/java/jp/classmethod/sparrow/model/CalcServiceTest.java
@@ -46,7 +46,7 @@ public class CalcServiceTest {
 	
 	
 	/**
-	 * linebotservice#validateRequestSignatureの結果がfalseの時、例外を投げることを確認する
+	 * LineBotService#validateRequestSignatureの結果がfalseの時、例外を投げることを確認する
 	 */
 	@Test
 	public void budValidateTest() {
@@ -57,10 +57,10 @@ public class CalcServiceTest {
 				+ "\"message\":{\"type\":\"text\",\"id\":\"325708\",\"text\":\"start\",\"latitude\":0.0,\"longitude\":0.0},"
 				+ "\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\"}]}";
 		when(lineBotService.validateRequestSignature(anyString(), anyString())).thenReturn(false);
-		// exesice
+		// exercise
 		try {
 			sut.process(signature, requestBody);
-			fail(); //例外を投げなかった場合はテスト失敗
+			fail(); // 例外を投げなかった場合はテスト失敗
 		} catch (IllegalArgumentException e) {
 			assertTrue(true);
 		}

--- a/src/test/java/jp/classmethod/sparrow/model/CalclatorTest.java
+++ b/src/test/java/jp/classmethod/sparrow/model/CalclatorTest.java
@@ -60,10 +60,10 @@ public class CalclatorTest {
 		sut.save(resetEvent);
 		sut.save(numberEvent2);
 		sut.save(numberEvent3);
-		// exesice
-		int actual = sut.calculateTotal(totalEvent);
+		// exercise
+		String actual = sut.save(totalEvent);
 		// verify
-		assertThat(actual, is(24));
+		assertThat(actual, is("24"));
 	}
 	
 	/**
@@ -75,9 +75,9 @@ public class CalclatorTest {
 		LineEvent totalEvent =
 				LineEventFixture.createTotalLineUserEvent("U206d25c2ea6bd87c17655609a1c37cb8", 1499379060);
 		// exesice
-		int actual = sut.calculateTotal(totalEvent);
+		String actual = sut.save(totalEvent);
 		// verify
-		assertThat(actual, is(0));
+		assertThat(actual, is("0"));
 	}
 	
 	/**

--- a/src/test/java/jp/classmethod/sparrow/model/CalculatorTest.java
+++ b/src/test/java/jp/classmethod/sparrow/model/CalculatorTest.java
@@ -31,7 +31,7 @@ import jp.classmethod.sparrow.infrastructure.InMemoryLineMessageEntityRepository
  * Created by kunita.fumiko on 2017/05/10.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class CalclatorTest {
+public class CalculatorTest {
 	
 	@Spy
 	InMemoryLineMessageEntityRepository inMemoryLineMessageEntityRepository;
@@ -74,7 +74,7 @@ public class CalclatorTest {
 		// setup
 		LineEvent totalEvent =
 				LineEventFixture.createTotalLineUserEvent("U206d25c2ea6bd87c17655609a1c37cb8", 1499379060);
-		// exesice
+		// exercise
 		String actual = sut.save(totalEvent);
 		// verify
 		assertThat(actual, is("0"));
@@ -88,7 +88,7 @@ public class CalclatorTest {
 		// setup
 		LineEvent resetEvent =
 				LineEventFixture.createResetLineUserEvent("U206d25c2ea6bd87c17655609a1c37cb8", 1499379000);
-		// exesice
+		// exercise
 		String actual = sut.save(resetEvent);
 		// verify
 		assertThat(actual, is("reset"));
@@ -102,7 +102,7 @@ public class CalclatorTest {
 		// setup
 		LineEvent numberEvent =
 				LineEventFixture.createNumberLineUserEvent("U206d25c2ea6bd87c17655609a1c37cb8", 1499378880);
-		// exesice
+		// exercise
 		String actual = sut.save(numberEvent);
 		// verify
 		assertThat(actual, is(""));
@@ -116,14 +116,14 @@ public class CalclatorTest {
 		// setup
 		LineEvent invalidEvent =
 				LineEventFixture.createInvalidLineUserEvent("U206d25c2ea6bd87c17655609a1c37cb8", 1499379120);
-		// exesice
+		// exercise
 		String actual = sut.save(invalidEvent);
 		// verify
 		assertThat(actual, is("error"));
 	}
 	
 	/**
-	 * 引数で渡すLineMessegaEntityのuIdと一致するリストの合計値を返すことを確認します
+	 * 引数で渡すLineMessageEntityのuIdと一致するリストの合計値を返すことを確認します
 	 */
 	@Test
 	public void testCalculateTotal() {
@@ -165,9 +165,8 @@ public class CalclatorTest {
 		when(inMemoryLineMessageEntityRepository.save(numberLineMessageEntity6)).thenCallRealMethod();
 		when(inMemoryLineMessageEntityRepository.save(numberLineMessageEntity)).thenCallRealMethod();
 		
-		// exesice
+		// exercise
 		int result = sut.calculateTotal(totalEvent);
-		
 		// verify
 		assertThat(result, is(60));
 	}
@@ -176,13 +175,13 @@ public class CalclatorTest {
 	 *  数字発言時のLineEntity生成を確認します
 	 */
 	@Test
-	public void testcreateLineMessageEntity() {
+	public void testCreateLineMessageEntity() {
 		// setup
 		LineEvent startEvent =
 				LineEventFixture.createNumberLineUserEvent("U206d25c2ea6bd87c17655609a1c37cb8", 1499378820);
-		// exesice
+		// exercise
 		LineMessageEntity startLineMessageEntity = sut.createLineMessageEntity(startEvent);
-		// velify
+		// verify
 		assertThat(startLineMessageEntity.getMessageId(), is("325711"));
 		assertThat(startLineMessageEntity.getUserId(), is("U206d25c2ea6bd87c17655609a1c37cb8"));
 		assertThat(startLineMessageEntity.getTimestamp(), is(1499378820L));


### PR DESCRIPTION
# 概要
1. Calclatorのテスト対象メソッドを変更
1. Javadocの修正

# 内容
1. テスト対象をCalclator#calculateTotalではなく、calculateTotalの合計値を返すCalclator#savaに変更。
1. javadocの主説明とパラメータの間に空行を挿入
