### PR TITLE
add mysql-connector-java dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ dependencies {
 	compileOnly "org.projectlombok:lombok:$lombokVersion"
 
 	compile "com.h2database:h2:1.4.195"
+	compile "mysql:mysql-connector-java:5.1.42"
 	
 	// testing
 	testCompileOnly "org.projectlombok:lombok:$lombokVersion" // http://qiita.com/gillax/items/1cbcff003384087f2db1

--- a/src/main/scripts/afterInstall.sh
+++ b/src/main/scripts/afterInstall.sh
@@ -41,4 +41,5 @@ JAVA_OPTS="${JAVA_OPTS} -Dfile.encoding=UTF-8"
 JAVA_OPTS="${JAVA_OPTS} -Dserver.port=8080"
 
 export SPRING_APPLICATION_JSON=$(cat /opt/sparrow/application.json)
+export SPRING_PROFILES_ACTIVE=aws
 EOF


### PR DESCRIPTION
# 概要

デプロイ環境ではh2ではなくMySQLを使う想定をしていたが、現状の依存にMySQLのJDBCドライバが入っていなかったため追加しました。